### PR TITLE
fix: collect import specifiers from re-export statements

### DIFF
--- a/src/core/codegen/index.ts
+++ b/src/core/codegen/index.ts
@@ -1,6 +1,6 @@
 import { type Mapping, SourceMap, type VueCompilerOptions } from "@vue/language-core";
 import { camelize, capitalize } from "@vue/shared";
-import { findDynamicImports, findStaticImports } from "mlly";
+import { findDynamicImports, findExports, findStaticImports } from "mlly";
 import { toString } from "muggle-string";
 import { basename, extname } from "pathe";
 import { createCompilerOptionsBuilder, parseLocalCompilerOptions } from "../compilerOptions";
@@ -50,6 +50,11 @@ export function createSourceFile(
     }
     for (const item of findDynamicImports(sourceText)) {
         sourceFile.imports.push(item.expression.slice(1, -1));
+    }
+    for (const item of findExports(sourceText)) {
+        if (item.specifier) {
+            sourceFile.imports.push(item.specifier);
+        }
     }
     for (const [, path] of sourceText.matchAll(referenceRE)) {
         sourceFile.references.push(path);

--- a/test/codegen.test.ts
+++ b/test/codegen.test.ts
@@ -91,3 +91,41 @@ describe("interpolation", () => {
         ).toContain("as typeof __VLS_ctx.bar");
     });
 });
+
+describe("metadata", () => {
+    it("import and re-export detection", () => {
+        const src = /* ts */`
+            import { foo } from "./foo";
+            import * as bar from "./bar";
+
+            export { default } from "./utils";
+            export * from "./components";
+            export * as prose from "./prose";
+        `;
+
+        const sourceFile = createSourceFile("dummy.ts", src, vueCompilerOptions);
+        expect(sourceFile.imports).toMatchInlineSnapshot(`
+          [
+            "./foo",
+            "./bar",
+            "./utils",
+            "./components",
+            "./prose",
+          ]
+        `);
+    });
+
+    it("reference detection", () => {
+        const src = /* ts */`
+            /// <reference path="./foo" />
+            /// <reference types="vue" />
+        `;
+
+        const sourceFile = createSourceFile("dummy.ts", src, vueCompilerOptions);
+        expect(sourceFile.references).toMatchInlineSnapshot(`
+          [
+            "./foo",
+          ]
+        `);
+    });
+});


### PR DESCRIPTION
Extracted from #5
