### PR TITLE
refactor: provide explicit `files` to avoid potential edge cases of path resolution

### DIFF
--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -164,8 +164,8 @@ export async function createProject(configPath: string): Promise<Project> {
             },
             // provide sorted file list to avoid type augments failure
             // caused by the random check order of tsgo internal logic
-            files: [...sourceToFiles.keys()]
-                .map((path) => relative(configRoot, path))
+            files: [...targetToFiles.keys()]
+                .map((path) => relative(targetRoot, path))
                 .sort(),
             include: void 0,
             exclude: void 0,

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -165,7 +165,7 @@ export async function createProject(configPath: string): Promise<Project> {
             // provide sorted file list to avoid type augments failure
             // caused by the random check order of tsgo internal logic
             files: [...targetToFiles.keys()]
-                .map((path) => relative(targetRoot, path))
+                .map((path) => relative(tsconfigDir, path))
                 .sort(),
             include: void 0,
             exclude: void 0,

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -154,12 +154,8 @@ export async function createProject(configPath: string): Promise<Project> {
                 files: [...(parsed.tsconfig.files ?? []), ...targetToFiles.keys()]
                     .map((tp) => relative(targetConfigDir, tp))
                     .sort(),
-                include: parsed.tsconfig.include?.map((path: string) => (
-                    isAbsolute(path) ? relative(configRoot, path) : path
-                )),
-                exclude: parsed.tsconfig.exclude?.map((path: string) => (
-                    isAbsolute(path) ? relative(configRoot, path) : path
-                )),
+                include: targetToFiles.size === 0 ? parsed.tsconfig.include : void 0,
+                exclude: targetToFiles.size === 0 ? parsed.tsconfig.exclude : void 0,
             };
 
             await mkdir(dirname(targetConfigPath), { recursive: true });

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -162,6 +162,7 @@ export async function createProject(configPath: string): Promise<Project> {
                     ...types.map((name) => join(vueCompilerOptions.typesRoot, name)),
                 ],
             },
+            // provide a explicit file list to avoid potential edge cases of path resolution
             files: [...targetToFiles.keys()].map((path) => relative(tsconfigDir, path)),
             include: void 0,
             exclude: void 0,

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -151,7 +151,7 @@ export async function createProject(configPath: string): Promise<Project> {
                         ...types.map((name) => join(vueCompilerOptions.typesRoot, name)),
                     ],
                 },
-                files: [...targetToFiles.keys()]
+                files: [...(parsed.tsconfig.files ?? []), ...targetToFiles.keys()]
                     .map((tp) => relative(targetConfigDir, tp))
                     .sort(),
                 include: parsed.tsconfig.include?.map((path: string) => (

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -162,11 +162,7 @@ export async function createProject(configPath: string): Promise<Project> {
                     ...types.map((name) => join(vueCompilerOptions.typesRoot, name)),
                 ],
             },
-            // provide sorted file list to avoid type augments failure
-            // caused by the random check order of tsgo internal logic
-            files: [...targetToFiles.keys()]
-                .map((path) => relative(tsconfigDir, path))
-                .sort(),
+            files: [...targetToFiles.keys()].map((path) => relative(tsconfigDir, path)),
             include: void 0,
             exclude: void 0,
         };

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -139,6 +139,7 @@ export async function createProject(configPath: string): Promise<Project> {
             }
 
             const targetConfigPath = toTargetPath(configPath);
+            const targetConfigDir = dirname(targetConfigPath);
             const targetConfig: TSConfig = {
                 ...parsed.tsconfig,
                 extends: void 0,
@@ -150,6 +151,9 @@ export async function createProject(configPath: string): Promise<Project> {
                         ...types.map((name) => join(vueCompilerOptions.typesRoot, name)),
                     ],
                 },
+                files: [...targetToFiles.keys()]
+                    .map((tp) => relative(targetConfigDir, tp))
+                    .sort(),
                 include: parsed.tsconfig.include?.map((path: string) => (
                     isAbsolute(path) ? relative(configRoot, path) : path
                 )),

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -163,7 +163,7 @@ export async function createProject(configPath: string): Promise<Project> {
                 ],
             },
             // provide a explicit file list to avoid potential edge cases of path resolution
-            files: [...targetToFiles.keys()].map((path) => relative(tsconfigDir, path)),
+            files: [...targetToFiles.keys()].map((path) => relative(tsconfigDir, path)).sort(),
             include: void 0,
             exclude: void 0,
         };


### PR DESCRIPTION
The issue is that `generate()` currently writes files to the target directory concurrently via [`Promise.all`](https://github.com/KazariEX/vue-tsgo/blob/d2adbaad4e486b3ee958e435d2fc7f1106a71bf9/src/core/project.ts#L172). This creates directory entries in non-deterministic order (depending on which `writeFile` calls complete first). When tsgo globs the directory using `include: ["**/*", ...]`, Linux `readdir` returns entries in their filesystem insertion order, which varies per run. `tsgo` appears to have a sensitivity to file discovery order — when something like a `module.ts` (containing the `declare module "***"` augmentation, [like in Nuxt UI](https://github.com/nuxt/ui/blob/b87704ebfc2bc1caa53637f4f51b4437e0627b4a/src/module.ts#L108-L114)) is discovered after the consumer `.vue.ts` files, the augmentation doesn't get applied in time for type-checking.